### PR TITLE
Fix Hierarchy#ancestors to show all ancestor paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ require 'hierarchy_tree'
 Hierarchy.associations(YourClass) # Array of hashes of relations → Representing the hierarchy symbolized relations
 Hierarchy.classes_list(YourClass) # Array of classes → Just a list of descendant classes, without representing the relations
 Hierarchy.classes(YourClass)      # Array of hashes of classes → Representing the hierarchy of relations as stringified classes instead of symbolized relations
-Hierarchy.all_ancestors(from: ChildClass, to: AncestorClass) # Array of relations → Representing all the possible paths starting from the ChildClass until it reaches AncestorClass
+Hierarchy.ancestors(from: ChildClass, to: AncestorClass) # Array of relations → Representing all the possible paths starting from the ChildClass until it reaches AncestorClass
 Hierarchy.ancestors_dfs(from: ChildClass, to: AncestorClass) # Hash of relations → Representing the ancestors hierarchy starting from the ChildClass until it reaches AncestorClass searching by Depth First Search
 Hierarchy.ancestors_bfs(from: ChildClass, to: AncestorClass) # Hash of relations → Representing the ancestors hierarchy starting from the ChildClass until it reaches AncestorClass searching by Breadth First Search
 ```
@@ -89,7 +89,7 @@ Hierarchy.classes_list(Book)
 # ["Page", "Line", "Word", "Letter"]
 
 Hierarchy.ancestors(from: Letter, to: Book)
-# [{:word=>:book}, {:word=>{:page=>:book}}]
+# [{:word=>:book}, {:word=>{:page=>:book}}, {:word=>{:line=>{:page=>:book}}}]
 
 Hierarchy.ancestors_dfs(from: Letter, to: Book)
 # {:word=>{:line=>{:page=>:book}}}

--- a/hierarchy_tree.gemspec
+++ b/hierarchy_tree.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'hierarchy-tree'
-  s.version               = '0.3.0'
+  s.version               = '0.3.1'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Victor Cordeiro Costa']
   s.email                 = ['victorcorcos@gmail.com']

--- a/lib/hierarchy_tree.rb
+++ b/lib/hierarchy_tree.rb
@@ -29,10 +29,10 @@ class Hierarchy
   # Return all the possible ancestors associations by navigating through :belongs_to
   # Starting from the "from" class towards the "to" class
   def self.ancestors(from:, to:)
-    return [] if from == to
+    return [] if from.to_s == to.to_s
 
-    queue = [{ class: from, path: [] }]
-    visited = { from => [] }
+    queue = [{ class: from.to_s, path: [] }]
+    visited = { from.to_s => [] }
     paths = []
 
     while queue.any?
@@ -40,15 +40,13 @@ class Hierarchy
       current_class = current[:class]
       current_path = current[:path]
 
-      current_class.reflect_on_all_associations(:belongs_to).each do |relation|
-        next_class = relation.klass
+      current_class.constantize.reflect_on_all_associations(:belongs_to).each do |relation|
+        next_class = relation.klass.to_s
         next_path = current_path + [relation.name]
 
-        if next_class.to_s == to.to_s
-          paths << hashify(next_path)
-        end
+        paths << hashify(next_path) if next_class == to.to_s
 
-        if !visited.key?(next_class)
+        if next_path == next_path.uniq # Non-looped path
           visited[next_class] = next_path
           queue.push({ class: next_class, path: next_path })
         end

--- a/test/test_hierarchy_tree.rb
+++ b/test/test_hierarchy_tree.rb
@@ -459,19 +459,21 @@ class TestHierarchyTree < Minitest::Test
   def test_all_ancestors
     setup_ancestors
 
-    assert_equal(Hierarchy.ancestors(from: Child, to: Parent1), [:parent1])
-    assert_equal(Hierarchy.ancestors(from: Child, to: Parent2), [:parent2])
-    assert_equal(Hierarchy.ancestors(from: Child, to: Parent3), [:parent3])
-    assert_equal(Hierarchy.ancestors(from: Child, to: GrandParent4), [{ parent1: :grand_parent4 }])
-    assert_equal(Hierarchy.ancestors(from: Child, to: GrandParent5), [{ parent2: :grand_parent5 }])
-    assert_equal(Hierarchy.ancestors(from: Child, to: GrandParent6), [{ parent3: :grand_parent6 }])
-    assert_equal(Hierarchy.ancestors(from: Child, to: God), [{ parent1: { grand_parent4: :god } }])
+    assert_equal(Hierarchy.ancestors(from: Child, to: Parent1), [:parent1, {:parent3=>{:grand_parent6=>{:child=>:parent1}}}])
+    assert_equal(Hierarchy.ancestors(from: Child, to: Parent2), [:parent2, {:parent3=>{:grand_parent6=>{:child=>:parent2}}}])
+    assert_equal(Hierarchy.ancestors(from: Child, to: Parent3), [:parent3, {:parent3=>{:grand_parent6=>{:child=>:parent3}}}])
+    assert_equal(Hierarchy.ancestors(from: Child, to: GrandParent4), [{:parent1=>:grand_parent4}, {:parent3=>{:grand_parent6=>{:child=>{:parent1=>:grand_parent4}}}}])
+    assert_equal(Hierarchy.ancestors(from: Child, to: GrandParent5), [{:parent2=>:grand_parent5}, {:parent3=>{:grand_parent6=>{:child=>{:parent2=>:grand_parent5}}}}])
+    assert_equal(Hierarchy.ancestors(from: Child, to: GrandParent6), [{:parent3=>:grand_parent6}])
+    assert_equal(Hierarchy.ancestors(from: Child, to: God), [{:parent1=>{:grand_parent4=>:god}}, {:parent3=>{:grand_parent6=>{:child=>{:parent1=>{:grand_parent4=>:god}}}}}])
 
     # Multiple Paths
     paths = [
-      { parent3: :edimar },
-      { parent2: { grand_parent5: :edimar } },
-      { parent1: { grand_parent4: { god: :edimar } } }
+      {:parent3=>:edimar},
+      {:parent2=>{:grand_parent5=>:edimar}},
+      {:parent1=>{:grand_parent4=>{:god=>:edimar}}},
+      {:parent3=>{:grand_parent6=>{:child=>{:parent2=>{:grand_parent5=>:edimar}}}}},
+      {:parent3=>{:grand_parent6=>{:child=>{:parent1=>{:grand_parent4=>{:god=>:edimar}}}}}}
     ]
     assert_equal(Hierarchy.ancestors(from: Child, to: Edimar), paths)
 
@@ -558,7 +560,7 @@ class TestHierarchyTree < Minitest::Test
     classes_list = ["Page", "Line", "Word", "Letter"]
     assert_equal(Hierarchy.classes_list(Book), classes_list)
 
-    ancestors = [{:word=>:book}, {:word=>{:page=>:book}}]
+    ancestors = [{:word=>:book}, {:word=>{:page=>:book}}, {:word=>{:line=>{:page=>:book}}}]
     assert_equal(Hierarchy.ancestors(from: Letter, to: Book), ancestors)
 
     ancestors_dfs = {:word=>{:line=>{:page=>:book}}}


### PR DESCRIPTION
# Description ✍️ 

Show all possible association PATHs on the `Hierarchy.ancestors(from:, to:)` method.


# Relations 🏛️ 

<img width="643" alt="Screen Shot 2023-10-25 at 05 08 27" src="https://github.com/Victorcorcos/hierarchy-tree/assets/7637806/be61357b-9512-45f0-8990-7dd448d52f1a">

```rb
Hierarchy.ancestors(from: Child, to: Edimar)
```

```rb
[
  {:parent3=>:edimar},
  {:parent2=>{:grand_parent5=>:edimar}},
  {:parent1=>{:grand_parent4=>{:god=>:edimar}}},
  {:parent3=>{:grand_parent6=>{:child=>{:parent2=>{:grand_parent5=>:edimar}}}}},
  {:parent3=>{:grand_parent6=>{:child=>{:parent1=>{:grand_parent4=>{:god=>:edimar}}}}}}
]
```



# Checks ☑️ 

- [x] Upgrade gem 0.3.0 → 0.3.1
- [x] Add tests
- [x] Fix Hierarchy.ancestors → Show all possible paths now
- [x] Update README